### PR TITLE
新規作成のときに、グループユーザーとチーム名を初期値でnullにする。

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -62,6 +62,8 @@ class RegisterController extends Controller
      */
     protected function create(array $data)
     {
+        $data['groupName'] = null;
+        $data['groupUser'] = null;
         return User::create([
             'name' => $data['name'],
             'email' => $data['email'],


### PR DESCRIPTION
グループユーザーとチーム名に初期値を入れる。